### PR TITLE
Use default opts for unmarshaling output state

### DIFF
--- a/rest/provider.go
+++ b/rest/provider.go
@@ -791,7 +791,7 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 
 // Update updates an existing resource with new values.
 func (p *Provider) Update(ctx context.Context, req *pulumirpc.UpdateRequest) (*pulumirpc.UpdateResponse, error) {
-	oldState, err := plugin.UnmarshalProperties(req.Olds, state.HTTPRequestBodyUnmarshalOpts)
+	oldState, err := plugin.UnmarshalProperties(req.Olds, state.DefaultUnmarshalOpts)
 	if err != nil {
 		return nil, errors.Wrap(err, "unmarshal olds as propertymap")
 	}

--- a/state/state.go
+++ b/state/state.go
@@ -30,6 +30,12 @@ func GetResourceState(outputs map[string]interface{}, inputs resource.PropertyMa
 // GetOldInputs returns the previously-stored inputs map from an outputs map.
 func GetOldInputs(state resource.PropertyMap) resource.PropertyMap {
 	if v, ok := state[stateKeyInputs]; ok {
+		// If the state was unmarshaled with HTTPRequestBodyUnmarshalOpts,
+		// then secret input property would have already been converted to
+		// its plain value.
+		if !v.IsSecret() {
+			return v.ObjectValue()
+		}
 		return v.SecretValue().Element.ObjectValue()
 	}
 


### PR DESCRIPTION
Here's a stack trace from a panic:

```
panic: interface conversion: interface {} is resource.PropertyMap, not *resource.Secret
    
    goroutine 57 [running]:
    github.com/pulumi/pulumi/sdk/v3/go/common/resource.PropertyValue.SecretValue(...)
    	/Users/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.158.0/go/common/resource/properties.go:471
    github.com/cloudy-sky-software/pulumi-provider-framework/state.GetOldInputs(...)
    	/Users/runner/go/pkg/mod/github.com/cloudy-sky-software/pulumi-provider-framework@v0.0.0-20250326153034-9c117b42f0fe/state/state.go:33
    github.com/cloudy-sky-software/pulumi-provider-framework/rest.(*Provider).getPathParamsMap(0x1400054c008, {0x14000908240, 0x2b}, {0x1058244ad, 0x6}, 0x14000971bc0)
    	/Users/runner/go/pkg/mod/github.com/cloudy-sky-software/pulumi-provider-framework@v0.0.0-20250326153034-9c117b42f0fe/rest/request.go:300 +0xcf8
    github.com/cloudy-sky-software/pulumi-provider-framework/rest.(*Provider).Delete(0x1400054c008, {0x105d6e858, 0x14000971b90}, 0x1400028a780)
    	/Users/runner/go/pkg/mod/github.com/cloudy-sky-software/pulumi-provider-framework@v0.0.0-20250326153034-9c117b42f0fe/rest/provider.go:963 +0x4dc
    github.com/pulumi/pulumi/sdk/v3/proto/go._ResourceProvider_Delete_Handler.func1({0x105d6e858?, 0x14000971b90?}, {0x105cbacc0?, 0x1400028a780?})
    	/Users/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.158.0/proto/go/provider_grpc.pb.go:987 +0xd0
    github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc.OpenTracingServerInterceptor.func1({0x105d6e858, 0x14000971560}, {0x105cbacc0, 0x1400028a780}, 0x14000818860, 0x14000d5ff38)
    	/Users/runner/go/pkg/mod/github.com/grpc-ecosystem/grpc-opentracing@v0.0.0-20180507213350-8e809c8a8645/go/otgrpc/server.go:57 +0x2cc
    github.com/pulumi/pulumi/sdk/v3/proto/go._ResourceProvider_Delete_Handler({0x105d3a3a0, 0x1400054c008}, {0x105d6e858, 0x14000971560}, 0x1400028a700, 0x1400048aac0)
    	/Users/runner/go/pkg/mod/github.com/pulumi/pulumi/sdk/v3@v3.158.0/proto/go/provider_grpc.pb.go:989 +0x148
    google.golang.org/grpc.(*Server).processUnaryRPC(0x14000369000, {0x105d6e858, 0x1400069c6c0}, 0x14000868060, 0x1400069c000, 0x10680a7d8, 0x0)
    	/Users/runner/go/pkg/mod/google.golang.org/grpc@v1.71.0/server.go:1405 +0xc9c
    google.golang.org/grpc.(*Server).handleStream(0x14000369000, {0x105d718f0, 0x1400089aea0}, 0x14000868060)
    	/Users/runner/go/pkg/mod/google.golang.org/grpc@v1.71.0/server.go:1815 +0x900
    google.golang.org/grpc.(*Server).serveStreams.func2.1()
    	/Users/runner/go/pkg/mod/google.golang.org/grpc@v1.71.0/server.go:1035 +0x84
    created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 56
    	/Users/runner/go/pkg/mod/google.golang.org/grpc@v1.71.0/server.go:1046 +0x138
```