### PR TITLE
Unmarshal old inputs and new inputs by unwrapping secrets for diffing

### DIFF
--- a/rest/provider.go
+++ b/rest/provider.go
@@ -337,7 +337,7 @@ func (p *Provider) Check(_ context.Context, req *pulumirpc.CheckRequest) (*pulum
 
 // Diff checks what impacts a hypothetical update will have on the resource's properties.
 func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulumirpc.DiffResponse, error) {
-	oldState, err := plugin.UnmarshalProperties(req.GetOlds(), state.DefaultUnmarshalOpts)
+	oldState, err := plugin.UnmarshalProperties(req.GetOlds(), state.HTTPRequestBodyUnmarshalOpts)
 	if err != nil {
 		return nil, err
 	}
@@ -353,7 +353,7 @@ func (p *Provider) Diff(ctx context.Context, req *pulumirpc.DiffRequest) (*pulum
 		return nil, errors.Errorf("unknown resource type %s", resourceTypeToken)
 	}
 
-	news, err := plugin.UnmarshalProperties(req.GetNews(), state.DefaultUnmarshalOpts)
+	news, err := plugin.UnmarshalProperties(req.GetNews(), state.HTTPRequestBodyUnmarshalOpts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Somewhat related to #407. In #407, secrets were unwrapped for HTTP request bodies sent to the provider. This PR fixes an issue where secrets were kept as secrets during "diffing" which leads to unnecessary diffs that can cause replacements.