### PR TITLE
Allow Provider baseUrl to be modified

### DIFF
--- a/rest/provider.go
+++ b/rest/provider.go
@@ -970,6 +970,10 @@ func (p *Provider) GetBaseURL() string {
 	return p.baseURL
 }
 
+func (p *Provider) SetBaseURL(baseURL string) {
+	p.baseURL = baseURL
+}
+
 func (p *Provider) GetHTTPClient() *http.Client {
 	return p.httpClient
 }

--- a/rest/provider.go
+++ b/rest/provider.go
@@ -172,8 +172,9 @@ func (p *Provider) Configure(ctx context.Context, req *pulumirpc.ConfigureReques
 	// Otherwise, this can be set via the API_HOST env var
 	apiHost, ok := req.GetVariables()[fmt.Sprintf("%s:config:apiHost", p.name)]
 	if !ok {
-		// Check if it's set in the API_HOST env var.
-		v := os.Getenv("API_HOST")
+		// Check if it's set in the {p.name}_API_HOST env var.
+		apiHostEnvVar := strings.ToUpper(strings.ReplaceAll(fmt.Sprintf("%s_API_HOST", p.name), "-", "_"))
+		v := os.Getenv(apiHostEnvVar)
 		if v != "" {
 			apiHost = v
 		}

--- a/rest/provider.go
+++ b/rest/provider.go
@@ -182,13 +182,13 @@ func (p *Provider) Configure(ctx context.Context, req *pulumirpc.ConfigureReques
 
 	if apiHost != "" {
 		logging.V(3).Infof("ApiHost overridden to %s", apiHost)
-		baseUrl, err := url.Parse(p.baseURL)
+		baseURL, err := url.Parse(p.baseURL)
 		if err != nil {
 			return nil, err
 		}
 
-		baseUrl.Host = apiHost
-		p.baseURL = baseUrl.String()
+		baseURL.Host = apiHost
+		p.baseURL = baseURL.String()
 
 		logging.V(3).Infof("Full API URL now %s", p.baseURL)
 	}

--- a/rest/provider.go
+++ b/rest/provider.go
@@ -169,7 +169,7 @@ func (p *Provider) Configure(ctx context.Context, req *pulumirpc.ConfigureReques
 	// Override the API host, if required. Intended for providers where the server names in the
 	// openapi spec will not match the API host that the provider needs to interact with during a deployment.
 	// To set via pulumi config, this will be "providername:apiHost"
-	// Otherwise, this can be set via the API_HOST env var
+	// Otherwise, this can be set via the PROVIDERNAME_API_HOST env var
 	apiHost, ok := req.GetVariables()[fmt.Sprintf("%s:config:apiHost", p.name)]
 	if !ok {
 		// Check if it's set in the {p.name}_API_HOST env var.

--- a/rest/provider.go
+++ b/rest/provider.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
+	"os"
 	"slices"
 	"strings"
 	"time"
@@ -162,6 +164,32 @@ func (p *Provider) Configure(ctx context.Context, req *pulumirpc.ConfigureReques
 	resp, err := p.providerCallback.OnConfigure(ctx, req)
 	if err != nil || resp != nil {
 		return resp, err
+	}
+
+	// Override the API host, if required. Intended for providers where the server names in the
+	// openapi spec will not match the API host that the provider needs to interact with during a deployment.
+	// To set via pulumi config, this will be "providername:apiHost"
+	// Otherwise, this can be set via the API_HOST env var
+	apiHost, ok := req.GetVariables()[fmt.Sprintf("%s:config:apiHost", p.name)]
+	if !ok {
+		// Check if it's set in the API_HOST env var.
+		v := os.Getenv("API_HOST")
+		if v != "" {
+			apiHost = v
+		}
+	}
+
+	if apiHost != "" {
+		logging.V(3).Infof("ApiHost overridden to %s", apiHost)
+		baseUrl, err := url.Parse(p.baseURL)
+		if err != nil {
+			return nil, err
+		}
+
+		baseUrl.Host = apiHost
+		p.baseURL = baseUrl.String()
+
+		logging.V(3).Infof("Full API URL now %s", p.baseURL)
 	}
 
 	return &pulumirpc.ConfigureResponse{
@@ -968,10 +996,6 @@ func (p *Provider) GetSchemaSpec() pschema.PackageSpec {
 
 func (p *Provider) GetBaseURL() string {
 	return p.baseURL
-}
-
-func (p *Provider) SetBaseURL(baseURL string) {
-	p.baseURL = baseURL
 }
 
 func (p *Provider) GetHTTPClient() *http.Client {

--- a/rest/provider_test.go
+++ b/rest/provider_test.go
@@ -310,7 +310,7 @@ func TestCreateWithSecretInput(t *testing.T) {
 func TestApiHostOverride(t *testing.T) {
 	ctx := context.Background()
 
-	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {}))
 	testServer.EnableHTTP2 = true
 	testServer.Start()
 
@@ -328,7 +328,7 @@ func TestApiHostOverride(t *testing.T) {
 func TestApiHostOverrideViaEnvVar(t *testing.T) {
 	ctx := context.Background()
 
-	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {}))
 	testServer.EnableHTTP2 = true
 	testServer.Start()
 
@@ -345,7 +345,7 @@ func TestApiHostOverrideViaEnvVar(t *testing.T) {
 func TestNoApiHostOverride(t *testing.T) {
 	ctx := context.Background()
 
-	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {}))
 	testServer.EnableHTTP2 = true
 	testServer.Start()
 

--- a/rest/provider_test.go
+++ b/rest/provider_test.go
@@ -310,7 +310,7 @@ func TestCreateWithSecretInput(t *testing.T) {
 func TestApiHostOverride(t *testing.T) {
 	ctx := context.Background()
 
-	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {}))
+	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 	testServer.EnableHTTP2 = true
 	testServer.Start()
 
@@ -328,7 +328,7 @@ func TestApiHostOverride(t *testing.T) {
 func TestApiHostOverrideViaEnvVar(t *testing.T) {
 	ctx := context.Background()
 
-	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {}))
+	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 	testServer.EnableHTTP2 = true
 	testServer.Start()
 
@@ -345,7 +345,7 @@ func TestApiHostOverrideViaEnvVar(t *testing.T) {
 func TestNoApiHostOverride(t *testing.T) {
 	ctx := context.Background()
 
-	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {}))
+	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {}))
 	testServer.EnableHTTP2 = true
 	testServer.Start()
 

--- a/rest/provider_test.go
+++ b/rest/provider_test.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-
 	"testing"
 
 	"github.com/cloudy-sky-software/pulumi-provider-framework/openapi"
@@ -322,6 +321,23 @@ func TestApiHostOverride(t *testing.T) {
 	_, err := p.Configure(ctx, &pulumirpc.ConfigureRequest{
 		Variables: map[string]string{"generic:config:apiHost": expectedHost},
 	})
+	assert.Nil(t, err)
+	assert.Equal(t, fmt.Sprintf("http://%s", expectedHost), p.(*Provider).GetBaseURL())
+}
+
+func TestApiHostOverrideViaEnvVar(t *testing.T) {
+	ctx := context.Background()
+
+	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	testServer.EnableHTTP2 = true
+	testServer.Start()
+
+	defer testServer.Close()
+	p := makeTestGenericProvider(ctx, t, testServer)
+
+	const expectedHost = "10.1.1.1"
+	t.Setenv("GENERIC_API_HOST", expectedHost)
+	_, err := p.Configure(ctx, &pulumirpc.ConfigureRequest{})
 	assert.Nil(t, err)
 	assert.Equal(t, fmt.Sprintf("http://%s", expectedHost), p.(*Provider).GetBaseURL())
 }

--- a/rest/provider_test.go
+++ b/rest/provider_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -305,4 +306,39 @@ func TestCreateWithSecretInput(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, createResp)
 	assert.Contains(t, createResp.GetProperties().AsMap(), "anotherProp")
+}
+
+func TestApiHostOverride(t *testing.T) {
+	ctx := context.Background()
+
+	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	testServer.EnableHTTP2 = true
+	testServer.Start()
+
+	defer testServer.Close()
+	p := makeTestGenericProvider(ctx, t, testServer)
+
+	const expectedHost = "10.1.1.1"
+	_, err := p.Configure(ctx, &pulumirpc.ConfigureRequest{
+		Variables: map[string]string{"generic:config:apiHost": expectedHost},
+	})
+	assert.Nil(t, err)
+	assert.Equal(t, fmt.Sprintf("http://%s", expectedHost), p.(*Provider).GetBaseURL())
+}
+
+func TestNoApiHostOverride(t *testing.T) {
+	ctx := context.Background()
+
+	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	testServer.EnableHTTP2 = true
+	testServer.Start()
+
+	defer testServer.Close()
+	p := makeTestGenericProvider(ctx, t, testServer)
+
+	expectedBaseURL := p.(*Provider).GetBaseURL()
+	_, err := p.Configure(ctx, &pulumirpc.ConfigureRequest{})
+
+	assert.Nil(t, err)
+	assert.Equal(t, expectedBaseURL, p.(*Provider).GetBaseURL())
 }

--- a/rest/transform_test.go
+++ b/rest/transform_test.go
@@ -37,7 +37,7 @@ func makeTestGenericProvider(ctx context.Context, t *testing.T, testServer *http
 	updatedOpenAPIDocBytes, _ := yaml.Marshal(updatedOpenAPIDoc)
 	metadataBytes, _ := json.Marshal(metadata)
 
-	p, err := MakeProvider(nil, "", "", schemaJSON, updatedOpenAPIDocBytes, metadataBytes, fakeProvider)
+	p, err := MakeProvider(nil, "generic", "", schemaJSON, updatedOpenAPIDocBytes, metadataBytes, fakeProvider)
 
 	if err != nil {
 		t.Fatalf("Could not create a provider instance: %v", err)


### PR DESCRIPTION
To support providers where the URL embedded in the `servers` section of an openapi spec may not be accurate during deployment (for example, for an api of a self-hosted platform), allow the `baseURL` field of the provider to be changed by an implementing provider.

E.g. in the Callback.OnConfigure method:
```
	apiHost, ok := req.GetVariables()["my-provider:config:apiHost"]
	if !ok {
            ...
	}

	logging.V(3).Info("Configuring API Host", apiHost)
	p.apiHost = apiHost

	logging.V(3).Infof("Fixing the base URL for the provider to use the configured API host: %s", p.apiHost)
	handler.SetBaseURL(fmt.Sprintf("https://%s%s", p.apiHost, handler.GetBaseURL()))
	logging.V(3).Infof("Base URL set to: %s", handler.GetBaseURL())
```


