### PR TITLE
Feature: Global Path Parameters - for APIs that have the same base path parameter on every path

### DIFF
--- a/callback/callback.go
+++ b/callback/callback.go
@@ -2,6 +2,7 @@ package callback
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -18,6 +19,10 @@ type ProviderCallback interface {
 	// OnConfigure is a hook for configuring the provider.
 	// Return a non-nil response to override the default behavior.
 	OnConfigure(ctx context.Context, req *pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error)
+
+	// GetGlobalPathParams returns a map of path parameters used across all (or most) requests
+	// This method is called during the Configure phase, but after the OnConfigure hook.
+	GetGlobalPathParams(ctx context.Context, req *pulumirpc.ConfigureRequest) (map[string]string, error)
 
 	OnPreInvoke(ctx context.Context, req *pulumirpc.InvokeRequest, httpReq *http.Request) error
 	OnPostInvoke(ctx context.Context, req *pulumirpc.InvokeRequest, outputs interface{}) (map[string]interface{}, error)
@@ -63,4 +68,62 @@ type ProviderCallback interface {
 	OnPreDelete(ctx context.Context, req *pulumirpc.DeleteRequest, httpReq *http.Request) error
 	// OnPostDelete is a hook for modifying the outputs.
 	OnPostDelete(ctx context.Context, req *pulumirpc.DeleteRequest) error
+}
+
+type UnimplementedProviderCallback struct{}
+
+func (UnimplementedProviderCallback) GetAuthorizationHeader() string {
+	return ""
+}
+
+func (UnimplementedProviderCallback) OnConfigure(context.Context, *pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
+	return nil, fmt.Errorf("OnConfigure not implemented")
+}
+
+func (UnimplementedProviderCallback) GetGlobalPathParams(context.Context, *pulumirpc.ConfigureRequest) (map[string]string, error) {
+	return nil, fmt.Errorf("OnConfigure not implemented")
+}
+
+func (UnimplementedProviderCallback) OnPreInvoke(context.Context, *pulumirpc.InvokeRequest, *http.Request) error {
+	return fmt.Errorf("OnPreInvoke not implemented")
+}
+
+func (UnimplementedProviderCallback) OnPostInvoke(context.Context, *pulumirpc.InvokeRequest, interface{}) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("OnPostInvoke not implemented")
+}
+
+func (UnimplementedProviderCallback) OnDiff(context.Context, *pulumirpc.DiffRequest, string, *resource.ObjectDiff, *openapi3.MediaType) (*pulumirpc.DiffResponse, error) {
+	return nil, fmt.Errorf("OnDiff not implemented")
+}
+
+func (UnimplementedProviderCallback) OnPreCreate(context.Context, *pulumirpc.CreateRequest, *http.Request) error {
+	return fmt.Errorf("OnPreCreate not implemented")
+}
+
+func (UnimplementedProviderCallback) OnPostCreate(context.Context, *pulumirpc.CreateRequest, interface{}) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("OnPostCreate not implemented")
+}
+
+func (UnimplementedProviderCallback) OnPreRead(context.Context, *pulumirpc.ReadRequest, *http.Request) error {
+	return fmt.Errorf("OnPreRead not implemented")
+}
+
+func (UnimplementedProviderCallback) OnPostRead(context.Context, *pulumirpc.ReadRequest, interface{}) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("OnPostRead not implemented")
+}
+
+func (UnimplementedProviderCallback) OnPreUpdate(context.Context, *pulumirpc.UpdateRequest, *http.Request) error {
+	return fmt.Errorf("OnPreUpdate not implemented")
+}
+
+func (UnimplementedProviderCallback) OnPostUpdate(context.Context, *pulumirpc.UpdateRequest, http.Request, interface{}) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("OnPostUpdate not implemented")
+}
+
+func (UnimplementedProviderCallback) OnPreDelete(context.Context, *pulumirpc.DeleteRequest, *http.Request) error {
+	return fmt.Errorf("OnPreDelete not implemented")
+}
+
+func (UnimplementedProviderCallback) OnPostDelete(context.Context, *pulumirpc.DeleteRequest) error {
+	return fmt.Errorf("OnPostDelete not implemented")
 }

--- a/callback/callback.go
+++ b/callback/callback.go
@@ -2,7 +2,7 @@ package callback
 
 import (
 	"context"
-	"fmt"
+	"github.com/pkg/errors"
 	"net/http"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -72,58 +72,54 @@ type ProviderCallback interface {
 
 type UnimplementedProviderCallback struct{}
 
-func (UnimplementedProviderCallback) GetAuthorizationHeader() string {
-	return ""
-}
-
 func (UnimplementedProviderCallback) OnConfigure(context.Context, *pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
-	return nil, fmt.Errorf("OnConfigure not implemented")
+	return nil, errors.New("OnConfigure not implemented")
 }
 
 func (UnimplementedProviderCallback) GetGlobalPathParams(context.Context, *pulumirpc.ConfigureRequest) (map[string]string, error) {
-	return nil, fmt.Errorf("OnConfigure not implemented")
+	return nil, nil
 }
 
 func (UnimplementedProviderCallback) OnPreInvoke(context.Context, *pulumirpc.InvokeRequest, *http.Request) error {
-	return fmt.Errorf("OnPreInvoke not implemented")
+	return errors.New("OnPreInvoke not implemented")
 }
 
 func (UnimplementedProviderCallback) OnPostInvoke(context.Context, *pulumirpc.InvokeRequest, interface{}) (map[string]interface{}, error) {
-	return nil, fmt.Errorf("OnPostInvoke not implemented")
+	return nil, errors.New("OnPostInvoke not implemented")
 }
 
 func (UnimplementedProviderCallback) OnDiff(context.Context, *pulumirpc.DiffRequest, string, *resource.ObjectDiff, *openapi3.MediaType) (*pulumirpc.DiffResponse, error) {
-	return nil, fmt.Errorf("OnDiff not implemented")
+	return nil, errors.New("OnDiff not implemented")
 }
 
 func (UnimplementedProviderCallback) OnPreCreate(context.Context, *pulumirpc.CreateRequest, *http.Request) error {
-	return fmt.Errorf("OnPreCreate not implemented")
+	return errors.New("OnPreCreate not implemented")
 }
 
 func (UnimplementedProviderCallback) OnPostCreate(context.Context, *pulumirpc.CreateRequest, interface{}) (map[string]interface{}, error) {
-	return nil, fmt.Errorf("OnPostCreate not implemented")
+	return nil, errors.New("OnPostCreate not implemented")
 }
 
 func (UnimplementedProviderCallback) OnPreRead(context.Context, *pulumirpc.ReadRequest, *http.Request) error {
-	return fmt.Errorf("OnPreRead not implemented")
+	return errors.New("OnPreRead not implemented")
 }
 
 func (UnimplementedProviderCallback) OnPostRead(context.Context, *pulumirpc.ReadRequest, interface{}) (map[string]interface{}, error) {
-	return nil, fmt.Errorf("OnPostRead not implemented")
+	return nil, errors.New("OnPostRead not implemented")
 }
 
 func (UnimplementedProviderCallback) OnPreUpdate(context.Context, *pulumirpc.UpdateRequest, *http.Request) error {
-	return fmt.Errorf("OnPreUpdate not implemented")
+	return errors.New("OnPreUpdate not implemented")
 }
 
 func (UnimplementedProviderCallback) OnPostUpdate(context.Context, *pulumirpc.UpdateRequest, http.Request, interface{}) (map[string]interface{}, error) {
-	return nil, fmt.Errorf("OnPostUpdate not implemented")
+	return nil, errors.New("OnPostUpdate not implemented")
 }
 
 func (UnimplementedProviderCallback) OnPreDelete(context.Context, *pulumirpc.DeleteRequest, *http.Request) error {
-	return fmt.Errorf("OnPreDelete not implemented")
+	return errors.New("OnPreDelete not implemented")
 }
 
 func (UnimplementedProviderCallback) OnPostDelete(context.Context, *pulumirpc.DeleteRequest) error {
-	return fmt.Errorf("OnPostDelete not implemented")
+	return errors.New("OnPostDelete not implemented")
 }

--- a/callback/callback.go
+++ b/callback/callback.go
@@ -2,7 +2,6 @@ package callback
 
 import (
 	"context"
-	"github.com/pkg/errors"
 	"net/http"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -73,7 +72,9 @@ type ProviderCallback interface {
 type UnimplementedProviderCallback struct{}
 
 func (UnimplementedProviderCallback) OnConfigure(context.Context, *pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
-	return nil, errors.New("OnConfigure not implemented")
+	return &pulumirpc.ConfigureResponse{
+		AcceptSecrets: true,
+	}, nil
 }
 
 func (UnimplementedProviderCallback) GetGlobalPathParams(context.Context, *pulumirpc.ConfigureRequest) (map[string]string, error) {
@@ -81,45 +82,45 @@ func (UnimplementedProviderCallback) GetGlobalPathParams(context.Context, *pulum
 }
 
 func (UnimplementedProviderCallback) OnPreInvoke(context.Context, *pulumirpc.InvokeRequest, *http.Request) error {
-	return errors.New("OnPreInvoke not implemented")
+	return nil
 }
 
-func (UnimplementedProviderCallback) OnPostInvoke(context.Context, *pulumirpc.InvokeRequest, interface{}) (map[string]interface{}, error) {
-	return nil, errors.New("OnPostInvoke not implemented")
+func (UnimplementedProviderCallback) OnPostInvoke(_ context.Context, _ *pulumirpc.InvokeRequest, outputs interface{}) (map[string]interface{}, error) {
+	return outputs.(map[string]interface{}), nil
 }
 
 func (UnimplementedProviderCallback) OnDiff(context.Context, *pulumirpc.DiffRequest, string, *resource.ObjectDiff, *openapi3.MediaType) (*pulumirpc.DiffResponse, error) {
-	return nil, errors.New("OnDiff not implemented")
+	return nil, nil
 }
 
 func (UnimplementedProviderCallback) OnPreCreate(context.Context, *pulumirpc.CreateRequest, *http.Request) error {
-	return errors.New("OnPreCreate not implemented")
+	return nil
 }
 
-func (UnimplementedProviderCallback) OnPostCreate(context.Context, *pulumirpc.CreateRequest, interface{}) (map[string]interface{}, error) {
-	return nil, errors.New("OnPostCreate not implemented")
+func (UnimplementedProviderCallback) OnPostCreate(_ context.Context, _ *pulumirpc.CreateRequest, outputs interface{}) (map[string]interface{}, error) {
+	return outputs.(map[string]interface{}), nil
 }
 
 func (UnimplementedProviderCallback) OnPreRead(context.Context, *pulumirpc.ReadRequest, *http.Request) error {
-	return errors.New("OnPreRead not implemented")
+	return nil
 }
 
-func (UnimplementedProviderCallback) OnPostRead(context.Context, *pulumirpc.ReadRequest, interface{}) (map[string]interface{}, error) {
-	return nil, errors.New("OnPostRead not implemented")
+func (UnimplementedProviderCallback) OnPostRead(_ context.Context, _ *pulumirpc.ReadRequest, outputs interface{}) (map[string]interface{}, error) {
+	return outputs.(map[string]interface{}), nil
 }
 
 func (UnimplementedProviderCallback) OnPreUpdate(context.Context, *pulumirpc.UpdateRequest, *http.Request) error {
-	return errors.New("OnPreUpdate not implemented")
+	return nil
 }
 
-func (UnimplementedProviderCallback) OnPostUpdate(context.Context, *pulumirpc.UpdateRequest, http.Request, interface{}) (map[string]interface{}, error) {
-	return nil, errors.New("OnPostUpdate not implemented")
+func (UnimplementedProviderCallback) OnPostUpdate(_ context.Context, _ *pulumirpc.UpdateRequest, _ http.Request, outputs interface{}) (map[string]interface{}, error) {
+	return outputs.(map[string]interface{}), nil
 }
 
 func (UnimplementedProviderCallback) OnPreDelete(context.Context, *pulumirpc.DeleteRequest, *http.Request) error {
-	return errors.New("OnPreDelete not implemented")
+	return nil
 }
 
 func (UnimplementedProviderCallback) OnPostDelete(context.Context, *pulumirpc.DeleteRequest) error {
-	return errors.New("OnPostDelete not implemented")
+	return nil
 }

--- a/rest/fake_provider.go
+++ b/rest/fake_provider.go
@@ -15,6 +15,7 @@ import (
 )
 
 type fakeProviderCallback struct {
+	globalPathParams map[string]string
 }
 
 var _ callback.ProviderCallback = &fakeProviderCallback{}
@@ -69,4 +70,8 @@ func (p *fakeProviderCallback) OnPreDelete(_ context.Context, _ *pulumirpc.Delet
 
 func (p *fakeProviderCallback) OnPostDelete(_ context.Context, _ *pulumirpc.DeleteRequest) error {
 	return nil
+}
+
+func (p *fakeProviderCallback) GetGlobalPathParams(_ context.Context, _ *pulumirpc.ConfigureRequest) (map[string]string, error) {
+	return p.globalPathParams, nil
 }

--- a/rest/provider.go
+++ b/rest/provider.go
@@ -120,7 +120,7 @@ func MakeProvider(host *provider.HostClient, name, version string, pulumiSchemaB
 		httpClient: httpClient,
 
 		providerCallback: callback,
-		globalPathParams: make(map[string]string), // initially an empty set
+		globalPathParams: make(map[string]string),
 	}, nil
 }
 

--- a/rest/provider.go
+++ b/rest/provider.go
@@ -171,6 +171,13 @@ func (p *Provider) Configure(ctx context.Context, req *pulumirpc.ConfigureReques
 		return resp, err
 	}
 
+	globalPathParams, err := p.providerCallback.GetGlobalPathParams(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting global path params")
+	} else if globalPathParams != nil {
+		p.globalPathParams = globalPathParams
+	}
+
 	// Override the API host, if required. Intended for providers where the server names in the
 	// openapi spec will not match the API host that the provider needs to interact with during a deployment.
 	// To set via pulumi config, this will be "providername:apiHost"
@@ -1010,10 +1017,4 @@ func (p *Provider) GetHTTPClient() *http.Client {
 
 func (p *Provider) GetMapping(_ context.Context, _ *pulumirpc.GetMappingRequest) (*pulumirpc.GetMappingResponse, error) {
 	return &pulumirpc.GetMappingResponse{}, nil
-}
-
-func (p *Provider) GetGlobalPathParams() map[string]string { return p.globalPathParams }
-
-func (p *Provider) GetMetadata() providerGen.ProviderMetadata {
-	return p.metadata
 }

--- a/rest/provider.go
+++ b/rest/provider.go
@@ -58,6 +58,10 @@ type Provider struct {
 	httpClient *http.Client
 	openAPIDoc openapi3.T
 	schema     pschema.PackageSpec
+
+	// Global path params for this provider - for path params that are fixed
+	// for a provider. Can be configured during the OnConfigure callback func
+	globalPathParams map[string]string
 }
 
 func defaultTransportDialContext(dialer *net.Dialer) func(context.Context, string, string) (net.Conn, error) {
@@ -116,6 +120,7 @@ func MakeProvider(host *provider.HostClient, name, version string, pulumiSchemaB
 		httpClient: httpClient,
 
 		providerCallback: callback,
+		globalPathParams: make(map[string]string), // initially an empty set
 	}, nil
 }
 
@@ -1005,4 +1010,10 @@ func (p *Provider) GetHTTPClient() *http.Client {
 
 func (p *Provider) GetMapping(_ context.Context, _ *pulumirpc.GetMappingRequest) (*pulumirpc.GetMappingResponse, error) {
 	return &pulumirpc.GetMappingResponse{}, nil
+}
+
+func (p *Provider) GetGlobalPathParams() map[string]string { return p.globalPathParams }
+
+func (p *Provider) GetMetadata() providerGen.ProviderMetadata {
+	return p.metadata
 }

--- a/rest/request.go
+++ b/rest/request.go
@@ -335,11 +335,19 @@ func (p *Provider) getPathParamsMap(apiPath, requestMethod string, properties re
 		// we have the old inputs, if we are dealing with the state
 		// of an existing resource.
 		if !ok {
+			logging.V(3).Infof("Global Params Map: %v, sdkName: %s", p.globalPathParams, sdkName)
 			// Try to see if a top-level property has the required prop perhaps.
 			_, topLevelPropName, ok := tryPluckingProp(sdkName, properties.Mappable())
 			if ok {
 				topLevelProp := properties[resource.PropertyKey(topLevelPropName)]
 				property = topLevelProp.ObjectValue()[resource.PropertyKey(sdkName)]
+			} else if globalPathParam, ok := p.globalPathParams[sdkName]; ok {
+				// Is the property a global path param set in the provider?
+				// We look for this after checking the resource state, so it can be overridden at a resource level
+				logging.V(3).Infof("Path param %q is a global path param with value %q", sdkName, globalPathParam)
+				property = resource.PropertyValue{
+					V: globalPathParam,
+				}
 			} else {
 				if oldInputs == nil {
 					return nil, errors.Errorf("did not find value for path param %s in output props (old inputs was nil)", paramName)

--- a/rest/request_test.go
+++ b/rest/request_test.go
@@ -50,6 +50,26 @@ func TestRemovePathParamsFromRequestBody(t *testing.T) {
 	assert.False(t, ok, "Expected tailnet to be removed from the HTTP request body since it is a path param.")
 }
 
+func TestProviderGlobalPathParams(t *testing.T) {
+	ctx := context.Background()
+	testCreateJSONPayload := `{}`
+
+	expectedBaseId := "fake-base-id"
+
+	var inputs map[string]interface{}
+	if err := json.Unmarshal([]byte(testCreateJSONPayload), &inputs); err != nil {
+		t.Fatalf("Failed to unmarshal test payload: %v", err)
+	}
+
+	p := makeTestGenericProvider(ctx, t, nil)
+	p.(*Provider).GetGlobalPathParams()["baseId"] = expectedBaseId
+
+	httpReq, err := p.(Request).CreatePostRequest(ctx, "/v2/{baseId}/fakeresource", []byte(testCreateJSONPayload), resource.NewPropertyMapFromMap(inputs))
+	assert.Nil(t, err)
+	assert.NotNil(t, httpReq)
+	assert.Equal(t, httpReq.URL.Path, "/v2/"+expectedBaseId+"/fakeresource")
+}
+
 func TestLastPathParamIsResourceId(t *testing.T) {
 	ctx := context.Background()
 

--- a/rest/request_test.go
+++ b/rest/request_test.go
@@ -54,7 +54,7 @@ func TestProviderGlobalPathParams(t *testing.T) {
 	ctx := context.Background()
 	testCreateJSONPayload := `{}`
 
-	expectedBaseId := "fake-base-id"
+	expectedBaseID := "fake-base-id"
 
 	var inputs map[string]interface{}
 	if err := json.Unmarshal([]byte(testCreateJSONPayload), &inputs); err != nil {
@@ -62,12 +62,12 @@ func TestProviderGlobalPathParams(t *testing.T) {
 	}
 
 	p := makeTestGenericProvider(ctx, t, nil)
-	p.(*Provider).GetGlobalPathParams()["baseId"] = expectedBaseId
+	p.(*Provider).GetGlobalPathParams()["baseId"] = expectedBaseID
 
 	httpReq, err := p.(Request).CreatePostRequest(ctx, "/v2/{baseId}/fakeresource", []byte(testCreateJSONPayload), resource.NewPropertyMapFromMap(inputs))
 	assert.Nil(t, err)
 	assert.NotNil(t, httpReq)
-	assert.Equal(t, httpReq.URL.Path, "/v2/"+expectedBaseId+"/fakeresource")
+	assert.Equal(t, httpReq.URL.Path, "/v2/"+expectedBaseID+"/fakeresource")
 }
 
 func TestLastPathParamIsResourceId(t *testing.T) {

--- a/rest/request_test.go
+++ b/rest/request_test.go
@@ -34,7 +34,7 @@ func TestRemovePathParamsFromRequestBody(t *testing.T) {
 		t.Fatalf("Failed to unmarshal test payload: %v", err)
 	}
 
-	p := makeTestTailscaleProvider(ctx, t, nil)
+	p := makeTestTailscaleProvider(ctx, t, nil, nil)
 	httpReq, err := p.(Request).CreatePostRequest(ctx, "/tailnet/{tailnet}/keys", []byte(testCreateJSONPayload), resource.NewPropertyMapFromMap(inputs))
 	assert.Nil(t, err)
 	assert.NotNil(t, httpReq)
@@ -61,8 +61,11 @@ func TestProviderGlobalPathParams(t *testing.T) {
 		t.Fatalf("Failed to unmarshal test payload: %v", err)
 	}
 
-	p := makeTestGenericProvider(ctx, t, nil)
-	p.(*Provider).GetGlobalPathParams()["baseId"] = expectedBaseID
+	p := makeTestGenericProvider(ctx, t, nil, &fakeProviderCallback{
+		globalPathParams: map[string]string{
+			"baseId": expectedBaseID,
+		},
+	})
 
 	httpReq, err := p.(Request).CreatePostRequest(ctx, "/v2/{baseId}/fakeresource", []byte(testCreateJSONPayload), resource.NewPropertyMapFromMap(inputs))
 	assert.Nil(t, err)
@@ -73,7 +76,7 @@ func TestProviderGlobalPathParams(t *testing.T) {
 func TestLastPathParamIsResourceId(t *testing.T) {
 	ctx := context.Background()
 
-	p := makeTestGenericProvider(ctx, t, nil)
+	p := makeTestGenericProvider(ctx, t, nil, nil)
 
 	properties := map[string]interface{}{
 		"id": "fake-id",

--- a/rest/testdata/generic/openapi.yml
+++ b/rest/testdata/generic/openapi.yml
@@ -104,3 +104,25 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/response_object_type"
+
+  /v2/{baseId}/fakeresource:
+    post:
+      operationId: create_base_fake_resource
+      parameters:
+        - name: baseId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/request_object_type"
+      responses:
+        "200":
+          description: The response for creating a base fake resource.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/response_object_type"


### PR DESCRIPTION
The Unifi API has a `siteId` path parameter that appears in (almost) all paths in the API. See: https://github.com/bbbates/pulumi-unifi-native/blob/81e014360d23ce5172b7e8d8f41a933bd5d0bef6/provider/cmd/pulumi-gen-unifi-native/openapi.yml#L12  (and in all the paths).

Ideally, users of the provider should not need to set this in each of their resources, as it would be quite noisy.

This feature is to allow a provider to encapsulate a map of global path parameters that can be defined outside of a resource (i.e. via configuration) and used when populating the set of path parameters for a request. The global path params are checked last when building the request path param map, so they can be overridden by resources if required. 

For example, this is how the current version of the Unifi provider configures this feature: https://github.com/bbbates/pulumi-unifi-native/blob/81e014360d23ce5172b7e8d8f41a933bd5d0bef6/provider/pkg/provider/provider.go#L152C1-L175C3 

```
func (p *unifiNativeProvider) OnConfigure(_ context.Context, req *pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
	siteId, ok := req.GetVariables()["unifi-native:config:siteId"]
	if !ok {
		// Check if it's set as an env var.
		envVarNames := handler.GetSchemaSpec().Provider.InputProperties["siteId"].DefaultInfo.Environment
		...
	}

	logging.V(3).Infof("Configuring Site Id: %s", siteId)
	p.siteId = siteId
	if p.siteId != "" {
		handler.GetGlobalPathParams()["siteId"] = p.siteId
		handler.GetGlobalPathParams()["site_id"] = p.siteId
	}
```

Again, happy to discuss alternative solutions!