### PR TITLE
Ensure provider API map key names are transformed to SDK names before diff'ing and saving to resource state

### DIFF
--- a/rest/provider.go
+++ b/rest/provider.go
@@ -757,6 +757,11 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 			dv = &val
 		}
 		openapi.FilterReadOnlyProperties(ctx, requestBodySchema, inputs, dv)
+
+		// Transform the inputs to match the API to SDK name map, which is assumed in later operations
+		var inputsMappable = inputs.Mappable()
+		p.TransformBody(ctx, inputsMappable, p.metadata.APIToSDKNameMap)
+		inputs = resource.NewPropertyMapFromMap(inputsMappable)
 	} else {
 		// Take the values from outputs and apply them to the inputs
 		// so that the checkpoint is in-sync with the state in the

--- a/rest/provider.go
+++ b/rest/provider.go
@@ -786,6 +786,12 @@ func (p *Provider) Read(ctx context.Context, req *pulumirpc.ReadRequest) (*pulum
 			dv = &val
 		}
 		openapi.FilterReadOnlyProperties(ctx, requestBodySchema, newState, dv)
+
+		// Transform the newState to match the API to SDK name map, which the inputs being diff'd with certainly will be
+		var newStateMappable = newState.Mappable()
+		p.TransformBody(ctx, newStateMappable, p.metadata.APIToSDKNameMap)
+		newState = resource.NewPropertyMapFromMap(newStateMappable)
+
 		inputs = state.ApplyDiffFromCloudProvider(newState, inputs)
 	}
 

--- a/rest/provider_test.go
+++ b/rest/provider_test.go
@@ -212,18 +212,18 @@ func TestDiffForUpdateableResource(t *testing.T) {
 	ctx := context.Background()
 
 	oldInputsJSON := `{
-		"object_prop": {
-			"another_prop": "a value"
+		"objectProp": {
+			"anotherProp": "a value"
 		}
 	}`
 
 	newInputsJSON := `{
-		"object_prop": {
-			"another_prop": "a value"
+		"objectProp": {
+			"anotherProp": "a value"
 		},
-		"simple_prop": "new value"
+		"simpleProp": "new value"
 	}`
-	outputsJSON := `{"another_prop":"output value"}`
+	outputsJSON := `{"anotherProp":"output value"}`
 
 	p := makeTestGenericProvider(ctx, t, nil, nil)
 
@@ -252,7 +252,7 @@ func TestDiffForUpdateableResource(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.NotNil(t, diffResp)
-	assert.Contains(t, diffResp.Diffs, "simple_prop")
+	assert.Contains(t, diffResp.Diffs, "simpleProp")
 }
 
 func TestCreateWithSecretInput(t *testing.T) {

--- a/rest/request.go
+++ b/rest/request.go
@@ -413,6 +413,8 @@ func (p *Provider) determineDiffsAndReplacements(d *resource.ObjectDiff, schemaR
 	replaces := make([]string, 0)
 	diffs := make([]string, 0)
 
+	apiNameLookupMap := p.metadata.SDKToAPINameMap
+
 	var properties openapi3.Schemas
 	if len(schemaRef.Value.Properties) > 0 {
 		properties = schemaRef.Value.Properties
@@ -429,7 +431,7 @@ func (p *Provider) determineDiffsAndReplacements(d *resource.ObjectDiff, schemaR
 		prop := string(propKey)
 		// If the added property is not part of the PATCH operation schema,
 		// then suggest a replacement triggered by this property.
-		if _, ok := properties[prop]; !ok {
+		if _, ok := properties[apiNameLookupMap[prop]]; !ok {
 			replaces = append(replaces, prop)
 		} else {
 			diffs = append(diffs, prop)
@@ -440,7 +442,7 @@ func (p *Provider) determineDiffsAndReplacements(d *resource.ObjectDiff, schemaR
 		prop := string(propKey)
 		// If the updated property is not part of the PATCH operation schema,
 		// then suggest a replacement triggered by this property.
-		if _, ok := properties[prop]; !ok {
+		if _, ok := properties[apiNameLookupMap[prop]]; !ok {
 			replaces = append(replaces, prop)
 		} else {
 			diffs = append(diffs, prop)
@@ -451,7 +453,7 @@ func (p *Provider) determineDiffsAndReplacements(d *resource.ObjectDiff, schemaR
 		prop := string(propKey)
 		// If the deleted property is not part of the PATCH operation schema,
 		// then suggest a replacement triggered by this property.
-		if _, ok := properties[prop]; !ok {
+		if _, ok := properties[apiNameLookupMap[prop]]; !ok {
 			replaces = append(replaces, prop)
 		} else {
 			diffs = append(diffs, prop)

--- a/rest/request.go
+++ b/rest/request.go
@@ -431,7 +431,8 @@ func (p *Provider) determineDiffsAndReplacements(d *resource.ObjectDiff, schemaR
 		prop := string(propKey)
 		// If the added property is not part of the PATCH operation schema,
 		// then suggest a replacement triggered by this property.
-		if _, ok := properties[apiNameLookupMap[prop]]; !ok {
+
+		if _, ok := properties[GetOrKey(apiNameLookupMap, prop)]; !ok {
 			replaces = append(replaces, prop)
 		} else {
 			diffs = append(diffs, prop)
@@ -442,7 +443,7 @@ func (p *Provider) determineDiffsAndReplacements(d *resource.ObjectDiff, schemaR
 		prop := string(propKey)
 		// If the updated property is not part of the PATCH operation schema,
 		// then suggest a replacement triggered by this property.
-		if _, ok := properties[apiNameLookupMap[prop]]; !ok {
+		if _, ok := properties[GetOrKey(apiNameLookupMap, prop)]; !ok {
 			replaces = append(replaces, prop)
 		} else {
 			diffs = append(diffs, prop)
@@ -453,7 +454,7 @@ func (p *Provider) determineDiffsAndReplacements(d *resource.ObjectDiff, schemaR
 		prop := string(propKey)
 		// If the deleted property is not part of the PATCH operation schema,
 		// then suggest a replacement triggered by this property.
-		if _, ok := properties[apiNameLookupMap[prop]]; !ok {
+		if _, ok := properties[GetOrKey(apiNameLookupMap, prop)]; !ok {
 			replaces = append(replaces, prop)
 		} else {
 			diffs = append(diffs, prop)

--- a/rest/transform.go
+++ b/rest/transform.go
@@ -14,10 +14,7 @@ func (p *Provider) TransformBody(ctx context.Context, bodyMap map[string]interfa
 	}
 
 	for sdkName, v := range bodyMap {
-		apiName := sdkName
-		if overriddenName, ok := lookupMap[sdkName]; ok {
-			apiName = overriddenName
-		}
+		apiName := GetOrKey(lookupMap, sdkName)
 
 		switch val := v.(type) {
 		case map[string]interface{}:
@@ -40,6 +37,16 @@ func (p *Provider) TransformBody(ctx context.Context, bodyMap map[string]interfa
 
 		bodyMap[apiName] = v
 	}
+}
+
+// GetOrKey Lookup key in the map and return the value if it exists, or else return the key
+// This is useful when using the API to SDK name (and vice-versa) maps, where if the key
+// does not exist in the map, the key is the same in both SDK and API.
+func GetOrKey(m map[string]string, key string) string {
+	if val, ok := m[key]; ok {
+		return val
+	}
+	return key
 }
 
 func convertNumericIDToString(val interface{}) string {


### PR DESCRIPTION
This change fixes a bug that occurs in the following scenario:

- The provider's API attribute naming scheme differs from the standard SDK naming scheme (camelCaseLower)
- A resource is imported (`pulumi import`) or refreshed (`pulumi refresh`)

Prior to this fix, when reading and diff'ing state from the remote provider API, the existing "input" fields from the state and the output from the provider API are compared - the fields that are cased differently are not matched correctly, and both fields are stored in the stack's state for that resource. This causes issues when a `pulumi up` command is executed later, as pulumi assumes that state has changed and attempts to remove the misnamed fields.

This fix ensures the incoming keys are transformed correctly to the SDK naming scheme before diff'ing and storing the resource state.