### PR TITLE
Fix issue with apiHost configuration override and failing request validation

### DIFF
--- a/rest/provider.go
+++ b/rest/provider.go
@@ -209,11 +209,11 @@ func (p *Provider) Configure(ctx context.Context, req *pulumirpc.ConfigureReques
 
 	if callbackResp != nil {
 		return callbackResp, nil
-	} else {
-		return &pulumirpc.ConfigureResponse{
-			AcceptSecrets: true,
-		}, nil
 	}
+
+	return &pulumirpc.ConfigureResponse{
+		AcceptSecrets: true,
+	}, nil
 }
 
 func (p *Provider) convertInvokeOutput(_ context.Context, req *pulumirpc.InvokeRequest, outputs interface{}) (map[string]interface{}, error) {

--- a/rest/provider.go
+++ b/rest/provider.go
@@ -159,18 +159,6 @@ func (p *Provider) DiffConfig(_ context.Context, _ *pulumirpc.DiffRequest) (*pul
 
 // Configure configures the resource provider with "globals" that control its behavior.
 func (p *Provider) Configure(ctx context.Context, req *pulumirpc.ConfigureRequest) (*pulumirpc.ConfigureResponse, error) {
-	callbackResp, err := p.providerCallback.OnConfigure(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-
-	globalPathParams, err := p.providerCallback.GetGlobalPathParams(ctx, req)
-	if err != nil {
-		return nil, errors.Wrap(err, "getting global path params")
-	} else if globalPathParams != nil {
-		p.globalPathParams = globalPathParams
-	}
-
 	// Override the API host, if required. Intended for providers where the server names in the
 	// openapi spec will not match the API host that the provider needs to interact with during a deployment.
 	// To set via pulumi config, this will be "providername:apiHost"
@@ -206,6 +194,18 @@ func (p *Provider) Configure(ctx context.Context, req *pulumirpc.ConfigureReques
 		return nil, errors.Wrap(err, "creating api router mux")
 	}
 	p.router = router
+
+	callbackResp, err := p.providerCallback.OnConfigure(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	globalPathParams, err := p.providerCallback.GetGlobalPathParams(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting global path params")
+	} else if globalPathParams != nil {
+		p.globalPathParams = globalPathParams
+	}
 
 	if callbackResp != nil {
 		return callbackResp, nil

--- a/rest/provider_test.go
+++ b/rest/provider_test.go
@@ -329,6 +329,11 @@ func TestApiHostOverride(t *testing.T) {
 	})
 	assert.Nil(t, err)
 	assert.Equal(t, fmt.Sprintf("http://%s", expectedHost), p.(*Provider).GetBaseURL())
+
+	// verify requests are still matched when using an overridden api host name
+	request, err := p.(*Provider).CreateGetRequest(ctx, "/v2/fakeresource/{resourceId}", resource.NewPropertyMapFromMap(map[string]interface{}{"resourceId": "12345"}))
+	assert.Nil(t, err)
+	assert.Equal(t, request.URL.String(), fmt.Sprintf("http://%s/v2/fakeresource/12345", expectedHost), "Expected request to be matched when using an overridden api host name")
 }
 
 func TestApiHostOverrideViaEnvVar(t *testing.T) {
@@ -346,6 +351,11 @@ func TestApiHostOverrideViaEnvVar(t *testing.T) {
 	_, err := p.Configure(ctx, &pulumirpc.ConfigureRequest{})
 	assert.Nil(t, err)
 	assert.Equal(t, fmt.Sprintf("http://%s", expectedHost), p.(*Provider).GetBaseURL())
+
+	// verify requests are still matched when using an overridden api host name
+	request, err := p.(*Provider).CreateGetRequest(ctx, "/v2/fakeresource/{resourceId}", resource.NewPropertyMapFromMap(map[string]interface{}{"resourceId": "12345"}))
+	assert.Nil(t, err)
+	assert.Equal(t, request.URL.String(), fmt.Sprintf("http://%s/v2/fakeresource/12345", expectedHost), "Expected request to be matched when using an overridden api host name")
 }
 
 func TestNoApiHostOverride(t *testing.T) {


### PR DESCRIPTION
I found an issue with the apiHost configuration override change I added in #447.

The `kin-openapi` `Router.FindRoute` method still uses the server URLs in the original OpenAPI document when resolving paths. This means that if the server host name is changed with the `apiHost` configuration item, path resolution via the `router`  (@ `rest/request.go:213`) always fails. 
The `kin-openapi` [documentation states](https://github.com/getkin/kin-openapi/blob/2de45f70d4afe6446074321af3f6d542e91f7f0d/routers/types.go#L14):
```
	// If you experience ErrPathNotFound and have localhost hosts specified as your servers,
	// turning these server URLs as relative (leaving only the path) should resolve this.
```
That explains why it was working for me before I submitted the PR - I was hand-mofifying the URLs in the openapi file to be relative paths! When I switched back to using the default URLs that the openapi spec provided, it started failing.

The fix I've used is to defer the creation of the `Provider.router` field until the `Provider.Configure` method, and update the server URL field in the OpenAPIDoc if the apiHost configuration property was provided. The `router` is only used to verify API requests, so is not required until after `Configure` is called, so this approach should work.

