### PR TITLE
Ensure Invoke output field names are correctly mapped to sdk names

### DIFF
--- a/rest/provider.go
+++ b/rest/provider.go
@@ -315,6 +315,8 @@ func (p *Provider) Invoke(ctx context.Context, req *pulumirpc.InvokeRequest) (*p
 		}
 	}
 
+	p.TransformBody(ctx, outputsMap, p.metadata.APIToSDKNameMap)
+
 	outputProperties, err := plugin.MarshalProperties(resource.NewPropertyMapFromMap(outputsMap), state.DefaultMarshalOpts)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshaling the output properties map")


### PR DESCRIPTION
Missed from #457 - field names returned from pulumi Function invocations need to follow the SDK naming conventions, as well. 



